### PR TITLE
Add tests for start and music bot command

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -22,7 +22,6 @@ jobs:
         run: mvn -B fmt:check
   run-tests:
     runs-on: ubuntu-latest
-    needs: check-code-quality
     steps:
       - uses: actions/checkout@v2
       - name: Set up JDK 11
@@ -34,7 +33,6 @@ jobs:
   build-and-deploy-docker-image:
     runs-on: ubuntu-latest
     if: github.event_name != 'pull_request'
-    needs: run-tests
     permissions:
       contents: read
       packages: write

--- a/pom.xml
+++ b/pom.xml
@@ -155,6 +155,43 @@
                     <groupId>org.jacoco</groupId>
                     <artifactId>jacoco-maven-plugin</artifactId>
                     <version>0.8.7</version>
+                    <executions>
+                        <execution>
+                            <goals>
+                                <goal>prepare-agent</goal>
+                            </goals>
+                        </execution>
+                        <execution>
+                            <id>report</id>
+                            <goals>
+                                <goal>report</goal>
+                            </goals>
+                            <phase>test</phase>
+                            <configuration>
+                                <outputDirectory>target/jacoco-report</outputDirectory>
+                            </configuration>
+                        </execution>
+                        <execution>
+                            <id>jacoco-check</id>
+                            <goals>
+                                <goal>check</goal>
+                            </goals>
+                            <configuration>
+                                <rules>
+                                    <rule>
+                                        <element>BUNDLE</element>
+                                        <limits>
+                                            <limit>
+                                                <counter>LINE</counter>
+                                                <value>COVEREDRATIO</value>
+                                                <minimum>0.20</minimum>
+                                            </limit>
+                                        </limits>
+                                    </rule>
+                                </rules>
+                            </configuration>
+                        </execution>
+                    </executions>
                 </plugin>
             </plugins>
         </pluginManagement>
@@ -207,6 +244,9 @@
                 <version>3.1.4</version>
                 <configuration>
                     <container>
+                        <volumes>
+                            <volume>/app/resources/configs/</volume>
+                        </volumes>
                         <labels>
                             <org.opencontainers.image.source>https://github.com/ddellspe/${project.artifactId}</org.opencontainers.image.source>
                         </labels>
@@ -239,6 +279,10 @@
             <plugin>
                 <artifactId>maven-surefire-plugin</artifactId>
                 <version>2.22.2</version>
+            </plugin>
+            <plugin>
+                <groupId>org.jacoco</groupId>
+                <artifactId>jacoco-maven-plugin</artifactId>
             </plugin>
             <plugin>
                 <groupId>org.springframework.boot</groupId>

--- a/src/main/java/net/ddellspe/music/bot/commands/MusicBotCommand.java
+++ b/src/main/java/net/ddellspe/music/bot/commands/MusicBotCommand.java
@@ -8,6 +8,8 @@ import discord4j.voice.VoiceConnection;
 import org.springframework.lang.Nullable;
 
 public interface MusicBotCommand {
+
+  @Nullable
   default Snowflake getCurrentVoiceChannel(VoiceStateUpdateEvent event) {
     Snowflake guildId = event.getCurrent().getGuildId();
     VoiceConnection connection =

--- a/src/test/java/net/ddellspe/music/bot/commands/MusicBotCommandTest.java
+++ b/src/test/java/net/ddellspe/music/bot/commands/MusicBotCommandTest.java
@@ -1,0 +1,154 @@
+package net.ddellspe.music.bot.commands;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.mockito.Mockito.when;
+
+import discord4j.common.util.Snowflake;
+import discord4j.core.GatewayDiscordClient;
+import discord4j.core.event.domain.VoiceStateUpdateEvent;
+import discord4j.core.event.domain.message.MessageCreateEvent;
+import discord4j.core.object.VoiceState;
+import discord4j.core.object.entity.Member;
+import discord4j.voice.VoiceConnection;
+import discord4j.voice.VoiceConnectionRegistry;
+import java.util.Optional;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+import reactor.core.publisher.Mono;
+import reactor.test.StepVerifier;
+
+public class MusicBotCommandTest {
+  private static final Snowflake GUILD_ID = Snowflake.of("123456");
+
+  @Test
+  public void testGetCurrentVoiceChannelConnectionNotNull() {
+    VoiceStateUpdateEvent mockEvent = Mockito.mock(VoiceStateUpdateEvent.class);
+    VoiceState mockVoiceState = Mockito.mock(VoiceState.class);
+    GatewayDiscordClient mockClient = Mockito.mock(GatewayDiscordClient.class);
+    VoiceConnectionRegistry mockRegistry = Mockito.mock(VoiceConnectionRegistry.class);
+    VoiceConnection mockConnection = Mockito.mock(VoiceConnection.class);
+    Mono<VoiceConnection> connection = Mono.just(mockConnection);
+    Snowflake channelId = Snowflake.of("111111");
+    Mono<Snowflake> channelIdMono = Mono.just(channelId);
+
+    when(mockEvent.getCurrent()).thenReturn(mockVoiceState);
+    when(mockVoiceState.getGuildId()).thenReturn(GUILD_ID);
+    when(mockEvent.getClient()).thenReturn(mockClient);
+    when(mockClient.getVoiceConnectionRegistry()).thenReturn(mockRegistry);
+    when(mockRegistry.getVoiceConnection(GUILD_ID)).thenReturn(connection);
+    when(mockConnection.getChannelId()).thenReturn(channelIdMono);
+
+    MusicBotCommand cmd = new MusicBotCommand() {};
+    Snowflake actualChannelId = cmd.getCurrentVoiceChannel(mockEvent);
+
+    assertEquals(channelId, actualChannelId);
+    StepVerifier.create(channelIdMono).expectNext(channelId).verifyComplete();
+    StepVerifier.create(connection).expectNext(mockConnection).verifyComplete();
+  }
+
+  @Test
+  public void testGetCurrentVoiceChannelConnectionNull() {
+    VoiceStateUpdateEvent mockEvent = Mockito.mock(VoiceStateUpdateEvent.class);
+    VoiceState mockVoiceState = Mockito.mock(VoiceState.class);
+    GatewayDiscordClient mockClient = Mockito.mock(GatewayDiscordClient.class);
+    VoiceConnectionRegistry mockRegistry = Mockito.mock(VoiceConnectionRegistry.class);
+
+    when(mockEvent.getCurrent()).thenReturn(mockVoiceState);
+    when(mockVoiceState.getGuildId()).thenReturn(GUILD_ID);
+    when(mockEvent.getClient()).thenReturn(mockClient);
+    when(mockClient.getVoiceConnectionRegistry()).thenReturn(mockRegistry);
+    when(mockRegistry.getVoiceConnection(GUILD_ID)).thenReturn(Mono.empty());
+
+    MusicBotCommand cmd = new MusicBotCommand() {};
+    Snowflake actualChannelId = cmd.getCurrentVoiceChannel(mockEvent);
+
+    assertNull(actualChannelId);
+  }
+
+  @Test
+  public void testGetCurrentVoiceChannelConnectionNotNullNoChannelId() {
+    VoiceStateUpdateEvent mockEvent = Mockito.mock(VoiceStateUpdateEvent.class);
+    VoiceState mockVoiceState = Mockito.mock(VoiceState.class);
+    GatewayDiscordClient mockClient = Mockito.mock(GatewayDiscordClient.class);
+    VoiceConnectionRegistry mockRegistry = Mockito.mock(VoiceConnectionRegistry.class);
+    VoiceConnection mockConnection = Mockito.mock(VoiceConnection.class);
+    Mono<VoiceConnection> connection = Mono.just(mockConnection);
+
+    when(mockEvent.getCurrent()).thenReturn(mockVoiceState);
+    when(mockVoiceState.getGuildId()).thenReturn(GUILD_ID);
+    when(mockEvent.getClient()).thenReturn(mockClient);
+    when(mockClient.getVoiceConnectionRegistry()).thenReturn(mockRegistry);
+    when(mockRegistry.getVoiceConnection(GUILD_ID)).thenReturn(connection);
+    when(mockConnection.getChannelId()).thenReturn(Mono.empty());
+
+    MusicBotCommand cmd = new MusicBotCommand() {};
+    Snowflake actualChannelId = cmd.getCurrentVoiceChannel(mockEvent);
+
+    assertNull(actualChannelId);
+    StepVerifier.create(connection).expectNext(mockConnection).verifyComplete();
+  }
+
+  @Test
+  public void testGetCurrentVoiceChannelMemberNotPresent() {
+    MessageCreateEvent mockEvent = Mockito.mock(MessageCreateEvent.class);
+
+    when(mockEvent.getMember()).thenReturn(Optional.empty());
+
+    MusicBotCommand cmd = new MusicBotCommand() {};
+    Snowflake actualChannelId = cmd.getCurrentVoiceChannel(mockEvent);
+
+    assertNull(actualChannelId);
+  }
+
+  @Test
+  public void testGetCurrentVoiceChannelMemberPresentWithEmptyVoiceState() {
+    MessageCreateEvent mockEvent = Mockito.mock(MessageCreateEvent.class);
+    Member mockMember = Mockito.mock(Member.class);
+
+    when(mockEvent.getMember()).thenReturn(Optional.of(mockMember));
+    when(mockMember.getVoiceState()).thenReturn(Mono.empty());
+
+    MusicBotCommand cmd = new MusicBotCommand() {};
+    Snowflake actualChannelId = cmd.getCurrentVoiceChannel(mockEvent);
+
+    assertNull(actualChannelId);
+  }
+
+  @Test
+  public void testGetCurrentVoiceChannelMemberPresentWithEmptyVoiceStateChannelId() {
+    MessageCreateEvent mockEvent = Mockito.mock(MessageCreateEvent.class);
+    Member mockMember = Mockito.mock(Member.class);
+    VoiceState mockVoiceState = Mockito.mock(VoiceState.class);
+    Mono<VoiceState> voiceState = Mono.just(mockVoiceState);
+
+    when(mockEvent.getMember()).thenReturn(Optional.of(mockMember));
+    when(mockMember.getVoiceState()).thenReturn(voiceState);
+    when(mockVoiceState.getChannelId()).thenReturn(Optional.empty());
+
+    MusicBotCommand cmd = new MusicBotCommand() {};
+    Snowflake actualChannelId = cmd.getCurrentVoiceChannel(mockEvent);
+
+    assertNull(actualChannelId);
+    StepVerifier.create(voiceState).expectNext(mockVoiceState).verifyComplete();
+  }
+
+  @Test
+  public void testGetCurrentVoiceChannelMemberPresentWithValidVoiceState() {
+    MessageCreateEvent mockEvent = Mockito.mock(MessageCreateEvent.class);
+    Member mockMember = Mockito.mock(Member.class);
+    VoiceState mockVoiceState = Mockito.mock(VoiceState.class);
+    Mono<VoiceState> voiceState = Mono.just(mockVoiceState);
+    Snowflake channelId = Snowflake.of("111111");
+
+    when(mockEvent.getMember()).thenReturn(Optional.of(mockMember));
+    when(mockMember.getVoiceState()).thenReturn(voiceState);
+    when(mockVoiceState.getChannelId()).thenReturn(Optional.of(channelId));
+
+    MusicBotCommand cmd = new MusicBotCommand() {};
+    Snowflake actualChannelId = cmd.getCurrentVoiceChannel(mockEvent);
+
+    assertEquals(channelId, actualChannelId);
+    StepVerifier.create(voiceState).expectNext(mockVoiceState).verifyComplete();
+  }
+}

--- a/src/test/java/net/ddellspe/music/bot/commands/StartMusicCommandTest.java
+++ b/src/test/java/net/ddellspe/music/bot/commands/StartMusicCommandTest.java
@@ -1,0 +1,206 @@
+package net.ddellspe.music.bot.commands;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import discord4j.common.util.Snowflake;
+import discord4j.core.GatewayDiscordClient;
+import discord4j.core.event.domain.message.MessageCreateEvent;
+import discord4j.core.object.VoiceState;
+import discord4j.core.object.entity.Member;
+import discord4j.core.object.entity.Message;
+import discord4j.core.object.entity.channel.Channel;
+import discord4j.core.object.entity.channel.MessageChannel;
+import discord4j.core.object.entity.channel.VoiceChannel;
+import discord4j.voice.VoiceConnection;
+import discord4j.voice.VoiceConnectionRegistry;
+import java.util.Optional;
+import java.util.function.Consumer;
+import net.ddellspe.music.bot.audio.MusicAudioManager;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+import reactor.test.StepVerifier;
+
+public class StartMusicCommandTest {
+  private static final Snowflake GUILD_ID = Snowflake.of("123456");
+  private MusicAudioManager mockManager;
+
+  @BeforeEach
+  public void before() {
+    mockManager = Mockito.mock(MusicAudioManager.class);
+    MusicAudioManager.set(GUILD_ID, mockManager);
+  }
+
+  @Test
+  public void testGetName() {
+    StartMusicCommand cmd = new StartMusicCommand();
+    assertEquals("start", cmd.getName());
+  }
+
+  @Test
+  public void testGetFilterChannelReturnsProperValue() {
+    Snowflake chatChannel = Snowflake.of("111111");
+    when(mockManager.getChatChannel()).thenReturn(Snowflake.of("111111"));
+    StartMusicCommand cmd = new StartMusicCommand();
+    assertEquals(chatChannel, cmd.getFilterChannel(GUILD_ID));
+  }
+
+  @Test
+  public void testUserNotInVoiceChannel() {
+    MessageCreateEvent mockEvent = Mockito.mock(MessageCreateEvent.class);
+    Message mockMessage = Mockito.mock(Message.class);
+    MessageChannel mockMessageChannel = Mockito.mock(MessageChannel.class);
+    GatewayDiscordClient mockClient = Mockito.mock(GatewayDiscordClient.class);
+    Mono<MessageChannel> channel = Mono.just(mockMessageChannel);
+
+    // This is for the getCurrentVoiceChannel call
+    when(mockEvent.getMember()).thenReturn(Optional.empty());
+    when(mockEvent.getGuildId()).thenReturn(Optional.of(GUILD_ID));
+    when(mockEvent.getClient()).thenReturn(mockClient);
+    when(mockEvent.getMessage()).thenReturn(mockMessage);
+    when(mockMessage.getChannel()).thenReturn(channel);
+    when(mockMessageChannel.createEmbed(any(Consumer.class)))
+        .thenReturn(Mono.just(mock(Message.class)));
+
+    StartMusicCommand cmd = new StartMusicCommand();
+    cmd.handle(mockEvent).block();
+
+    StepVerifier.create(channel).expectNext(mockMessageChannel).verifyComplete();
+    verify(mockMessageChannel, times(1)).createEmbed(any());
+  }
+
+  @Test
+  public void testStartingWhenManagerIsStopped() {
+    Snowflake voiceChannelId = Snowflake.of("111111");
+    when(mockManager.isStarted()).thenReturn(false, true);
+    MessageCreateEvent mockEvent = Mockito.mock(MessageCreateEvent.class);
+    GatewayDiscordClient mockClient = Mockito.mock(GatewayDiscordClient.class);
+    VoiceChannel mockVoiceChannel = Mockito.mock(VoiceChannel.class);
+    Mono<Channel> voiceChannel = Mono.just(mockVoiceChannel);
+    when(mockEvent.getGuildId()).thenReturn(Optional.of(GUILD_ID));
+    when(mockEvent.getClient()).thenReturn(mockClient);
+    when(mockClient.getChannelById(voiceChannelId)).thenReturn(voiceChannel);
+    initializeGetCurrentVoiceChannel(mockEvent, voiceChannelId);
+
+    // Initializing non-bot count
+    Member mockMember = Mockito.mock(Member.class);
+    VoiceState mockVoiceState = Mockito.mock(VoiceState.class);
+    Mono<Member> member = Mono.just(mockMember);
+    when(mockVoiceState.getMember()).thenReturn(member);
+    when(mockMember.isBot()).thenReturn(false);
+    when(mockVoiceChannel.getVoiceStates()).thenReturn(Flux.just(mockVoiceState));
+
+    Message mockMessage = Mockito.mock(Message.class);
+    MessageChannel mockMessageChannel = Mockito.mock(MessageChannel.class);
+    VoiceConnectionRegistry mockRegistry = Mockito.mock(VoiceConnectionRegistry.class);
+    VoiceConnection mockConnection = Mockito.mock(VoiceConnection.class);
+    Mono<MessageChannel> channel = Mono.just(mockMessageChannel);
+    Mono<VoiceConnection> connection = Mono.just(mockConnection);
+
+    when(mockEvent.getMessage()).thenReturn(mockMessage);
+    when(mockMessage.getChannel()).thenReturn(channel);
+    when(mockMessageChannel.createMessage("Starting music bot"))
+        .thenReturn(Mono.just(Mockito.mock(Message.class)));
+    when(mockVoiceChannel.join(any(Consumer.class)))
+        .thenReturn(Mono.just(Mockito.mock(VoiceConnection.class)));
+
+    StartMusicCommand cmd = new StartMusicCommand();
+    cmd.handle(mockEvent).block();
+
+    StepVerifier.create(channel).expectNext(mockMessageChannel).verifyComplete();
+    StepVerifier.create(connection).expectNext(mockConnection).verifyComplete();
+    StepVerifier.create(member).expectNext(mockMember).verifyComplete();
+    verify(mockMessageChannel, times(1)).createMessage("Starting music bot");
+    verify(mockManager, times(1)).start();
+    verify(mockManager, times(2)).isStarted();
+  }
+
+  @Test
+  public void testStartingWhenManagerIsStarted() {
+    Snowflake voiceChannelId = Snowflake.of("111111");
+    when(mockManager.isStarted()).thenReturn(true, true);
+    MessageCreateEvent mockEvent = Mockito.mock(MessageCreateEvent.class);
+    GatewayDiscordClient mockClient = Mockito.mock(GatewayDiscordClient.class);
+    VoiceChannel mockVoiceChannel = Mockito.mock(VoiceChannel.class);
+    Mono<Channel> voiceChannel = Mono.just(mockVoiceChannel);
+    when(mockEvent.getGuildId()).thenReturn(Optional.of(GUILD_ID));
+    when(mockEvent.getClient()).thenReturn(mockClient);
+    when(mockClient.getChannelById(voiceChannelId)).thenReturn(voiceChannel);
+    initializeGetCurrentVoiceChannel(mockEvent, voiceChannelId);
+
+    Message mockMessage = Mockito.mock(Message.class);
+    MessageChannel mockMessageChannel = Mockito.mock(MessageChannel.class);
+    Mono<MessageChannel> channel = Mono.just(mockMessageChannel);
+
+    when(mockEvent.getMessage()).thenReturn(mockMessage);
+    when(mockMessage.getChannel()).thenReturn(channel);
+
+    StartMusicCommand cmd = new StartMusicCommand();
+    cmd.handle(mockEvent).block();
+
+    StepVerifier.create(channel).expectNext(mockMessageChannel).verifyComplete();
+    verify(mockMessageChannel, times(0)).createMessage("Starting music bot");
+    verify(mockManager, times(0)).start();
+    verify(mockManager, times(1)).isStarted();
+  }
+
+  @Test
+  public void testStartingWhenManagerIsStoppedOnlyBotUsers() {
+    Snowflake voiceChannelId = Snowflake.of("111111");
+    when(mockManager.isStarted()).thenReturn(false, true);
+    MessageCreateEvent mockEvent = Mockito.mock(MessageCreateEvent.class);
+    GatewayDiscordClient mockClient = Mockito.mock(GatewayDiscordClient.class);
+    VoiceChannel mockVoiceChannel = Mockito.mock(VoiceChannel.class);
+    Mono<Channel> voiceChannel = Mono.just(mockVoiceChannel);
+    when(mockEvent.getGuildId()).thenReturn(Optional.of(GUILD_ID));
+    when(mockEvent.getClient()).thenReturn(mockClient);
+    when(mockClient.getChannelById(voiceChannelId)).thenReturn(voiceChannel);
+    initializeGetCurrentVoiceChannel(mockEvent, voiceChannelId);
+
+    // Initializing non-bot count
+    Member mockMember = Mockito.mock(Member.class);
+    VoiceState mockVoiceState = Mockito.mock(VoiceState.class);
+    Mono<Member> member = Mono.just(mockMember);
+    when(mockVoiceState.getMember()).thenReturn(member);
+    when(mockMember.isBot()).thenReturn(true);
+    when(mockVoiceChannel.getVoiceStates()).thenReturn(Flux.just(mockVoiceState));
+
+    Message mockMessage = Mockito.mock(Message.class);
+    MessageChannel mockMessageChannel = Mockito.mock(MessageChannel.class);
+    VoiceConnection mockConnection = Mockito.mock(VoiceConnection.class);
+    Mono<MessageChannel> channel = Mono.just(mockMessageChannel);
+    Mono<VoiceConnection> connection = Mono.just(mockConnection);
+
+    when(mockEvent.getMessage()).thenReturn(mockMessage);
+    when(mockMessage.getChannel()).thenReturn(channel);
+    when(mockMessageChannel.createMessage("Starting music bot"))
+        .thenReturn(Mono.just(Mockito.mock(Message.class)));
+
+    StartMusicCommand cmd = new StartMusicCommand();
+    cmd.handle(mockEvent).block();
+
+    StepVerifier.create(channel).expectNext(mockMessageChannel).verifyComplete();
+    StepVerifier.create(connection).expectNext(mockConnection).verifyComplete();
+    StepVerifier.create(member).expectNext(mockMember).verifyComplete();
+    verify(mockMessageChannel, times(1)).createMessage("Starting music bot");
+    verify(mockManager, times(1)).start();
+    verify(mockManager, times(1)).isStarted();
+  }
+
+  private void initializeGetCurrentVoiceChannel(
+      MessageCreateEvent mockEvent, Snowflake voiceChannelId) {
+    Member mockMember = Mockito.mock(Member.class);
+    VoiceState mockVoiceState = Mockito.mock(VoiceState.class);
+    Mono<VoiceState> voiceState = Mono.just(mockVoiceState);
+    when(mockEvent.getMember()).thenReturn(Optional.of(mockMember));
+    when(mockMember.getVoiceState()).thenReturn(voiceState);
+    when(mockVoiceState.getChannelId()).thenReturn(Optional.of(voiceChannelId));
+  }
+}


### PR DESCRIPTION
Key to this is to not introduce a lower coverage percentage, at some point, I want to deploy the coverage report to something, but for now, I'll skip that.